### PR TITLE
Add loading state to UserProfile

### DIFF
--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -22,6 +22,7 @@ export default function UserProfile({ userId: propUserId }) {
   const [average, setAverage] = useState(null);
   const [performance, setPerformance] = useState(null);
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!userId) return;
@@ -39,8 +40,11 @@ export default function UserProfile({ userId: propUserId }) {
         setPerformance(perf);
       } catch (err) {
         setError(err.message);
+      } finally {
+        setLoading(false);
       }
     }
+    setLoading(true);
     fetchData();
   }, [userId]);
 
@@ -49,6 +53,15 @@ export default function UserProfile({ userId: propUserId }) {
       <div>
         <Header />
         <p>Error: {error}</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div>
+        <Header />
+        <p>Chargement…</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- show a loading message while profile data is retrieved
- toggle loading before and after async fetch

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687b55353ffc8331b76cecb97319c631