### PR TITLE
Fix UserProfile loading state and add NotFound page

### DIFF
--- a/my-react-app/src/App.jsx
+++ b/my-react-app/src/App.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import Sidebar from './components/Sidebar.jsx';
 import UserProfile from './components/UserProfile.jsx';
+import NotFound from './components/NotFound.jsx';
 
 export default function App() {
   return (
@@ -10,6 +11,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Navigate to="/user/12" replace />} />
           <Route path="/user/:id" element={<UserProfile />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </div>
     </div>

--- a/my-react-app/src/components/NotFound.css
+++ b/my-react-app/src/components/NotFound.css
@@ -1,0 +1,10 @@
+.not-found {
+  text-align: center;
+  margin-top: 2rem;
+  font-family: "Roboto", sans-serif;
+}
+
+.not-found a {
+  color: #ff0101;
+  text-decoration: underline;
+}

--- a/my-react-app/src/components/NotFound.jsx
+++ b/my-react-app/src/components/NotFound.jsx
@@ -1,0 +1,14 @@
+import Header from './Header.jsx';
+import './NotFound.css';
+
+export default function NotFound() {
+  return (
+    <div>
+      <Header />
+      <div className="not-found">
+        <h2>Oups ! La page que vous demandez n'existe pas.</h2>
+        <a href="/user/12">Retourner sur la page d'accueil</a>
+      </div>
+    </div>
+  );
+}

--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -22,7 +22,7 @@ export default function UserProfile({ userId: propUserId }) {
   const [average, setAverage] = useState(null);
   const [performance, setPerformance] = useState(null);
   const [error, setError] = useState(null);
-  const [loading, setLoading] = useState(false);https://github.com/settings/emails?notice=one_verified_email
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (!userId) return;
@@ -39,14 +39,9 @@ export default function UserProfile({ userId: propUserId }) {
         setAverage(avg);
         setPerformance(perf);
       } catch (err) {
-        setError(err.message);
+        setError(err.message || 'Service indisponible');
       } finally {
         setLoading(false);
-        setMainData(null);
-        setActivity(null);
-        setAverage(null);
-        setPerformance(null);
-        setError(err.message || 'Service indisponible');
       }
     }
     setLoading(true);


### PR DESCRIPTION
## Summary
- add a simple NotFound component and route
- clean up `UserProfile` fetch logic
- show 404 page for unknown routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687b57dea2c8833199e2ac4e64e73164