### PR TITLE
Improve API error handling

### DIFF
--- a/my-react-app/src/components/ErrorMessage.css
+++ b/my-react-app/src/components/ErrorMessage.css
@@ -1,0 +1,14 @@
+.error-message {
+  text-align: center;
+  margin-top: 2rem;
+  font-family: "Roboto", sans-serif;
+}
+
+.error-message p {
+  color: #ff0101;
+}
+
+.error-message a {
+  color: #ff0101;
+  text-decoration: underline;
+}

--- a/my-react-app/src/components/ErrorMessage.jsx
+++ b/my-react-app/src/components/ErrorMessage.jsx
@@ -1,0 +1,15 @@
+import Header from './Header.jsx';
+import './ErrorMessage.css';
+
+export default function ErrorMessage({ message }) {
+  return (
+    <div>
+      <Header />
+      <div className="error-message">
+        <h2>Oups ! Une erreur est survenue.</h2>
+        <p>{message}</p>
+        <a href="/user/12">Retourner à l'accueil</a>
+      </div>
+    </div>
+  );
+}

--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import Header from './Header.jsx';
+import ErrorMessage from './ErrorMessage.jsx';
 import ActivityChart from './ActivityChart.jsx';
 import AverageSessionsChart from './AverageSessionsChart.jsx';
 import PerformanceRadarChart from './PerformanceRadarChart.jsx';
@@ -49,12 +50,7 @@ export default function UserProfile({ userId: propUserId }) {
   }, [userId]);
 
   if (error) {
-    return (
-      <div>
-        <Header />
-        <p>Error: {error}</p>
-      </div>
-    );
+    return <ErrorMessage message={error} />;
   }
 
   if (loading) {

--- a/my-react-app/src/services/userService.js
+++ b/my-react-app/src/services/userService.js
@@ -1,38 +1,35 @@
 // Base URL for API requests comes from the Vite environment variable
 const API_URL = import.meta.env.VITE_API_URL;
 
-export async function getUserMainData(id) {
-  const res = await fetch(`${API_URL}/${id}`);
-  if (!res.ok) {
-    throw new Error('Failed to fetch user main data');
+async function request(endpoint, defaultMessage) {
+  try {
+    const res = await fetch(endpoint);
+    const data = await res.json().catch(() => null);
+    if (!res.ok) {
+      const msg = data?.message || data?.error || defaultMessage;
+      throw new Error(msg);
+    }
+    return data?.data ?? data;
+  } catch (err) {
+    if (err instanceof TypeError) {
+      throw new Error('Service indisponible');
+    }
+    throw err;
   }
-  const json = await res.json();
-  return json.data;
 }
 
-export async function getUserActivity(id) {
-  const res = await fetch(`${API_URL}/${id}/activity`);
-  if (!res.ok) {
-    throw new Error('Failed to fetch user activity');
-  }
-  const json = await res.json();
-  return json.data;
+export function getUserMainData(id) {
+  return request(`${API_URL}/${id}`, 'Impossible de récupérer les données utilisateur');
 }
 
-export async function getUserAverageSessions(id) {
-  const res = await fetch(`${API_URL}/${id}/average-sessions`);
-  if (!res.ok) {
-    throw new Error('Failed to fetch user average sessions');
-  }
-  const json = await res.json();
-  return json.data;
+export function getUserActivity(id) {
+  return request(`${API_URL}/${id}/activity`, "Impossible de récupérer l'activité utilisateur");
 }
 
-export async function getUserPerformance(id) {
-  const res = await fetch(`${API_URL}/${id}/performance`);
-  if (!res.ok) {
-    throw new Error('Failed to fetch user performance');
-  }
-  const json = await res.json();
-  return json.data;
+export function getUserAverageSessions(id) {
+  return request(`${API_URL}/${id}/average-sessions`, 'Impossible de récupérer les sessions moyennes');
+}
+
+export function getUserPerformance(id) {
+  return request(`${API_URL}/${id}/performance`, 'Impossible de récupérer la performance');
 }


### PR DESCRIPTION
## Summary
- add `ErrorMessage` component and styling for nicer error display
- centralize API request handling in `request` helper
- use `ErrorMessage` in `UserProfile`
- show user-friendly fetch failure messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687b592f37948331b0d3e190f79298ce