### PR TITLE
Fix header responsiveness on small screens

### DIFF
--- a/my-react-app/src/components/Header.css
+++ b/my-react-app/src/components/Header.css
@@ -42,7 +42,34 @@
   margin: 0;
   padding: 0;
   align-items: center;
-  gap: 200px;
+  gap: 8rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+@media (max-width: 1024px) {
+  .nav-menu {
+    gap: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    height: auto;
+    padding: 1rem 2rem;
+  }
+
+  .nav-menu {
+    width: 100%;
+    justify-content: space-around;
+  }
+
+  .nav-menu li a {
+    line-height: normal;
+    padding: 0.5rem 0;
+  }
 }
 
 .nav-menu li a {

--- a/my-react-app/src/index.css
+++ b/my-react-app/src/index.css
@@ -31,6 +31,12 @@ body {
   box-sizing: border-box;
 }
 
+@media (max-width: 768px) {
+  body {
+    padding-top: 120px;
+  }
+}
+
 h1 {
   font-size: 3.2em;
   line-height: 1.1;


### PR DESCRIPTION
## Summary
- update header navigation layout to wrap and adjust gaps
- allow header to stack items on smaller screens
- add mobile body padding for taller header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687b5af965248331b922a0d4f17ca467