### PR TITLE
Add mock data source toggle

### DIFF
--- a/my-react-app/README.md
+++ b/my-react-app/README.md
@@ -18,6 +18,7 @@ Create a `.env` file in `my-react-app` to configure API access:
 
 ```env
 VITE_API_URL=http://localhost:3000
+VITE_USE_MOCKS=false
 ```
 
 ## Running the development servers
@@ -28,6 +29,9 @@ Start the backend API on `VITE_API_URL` (for example using `npm start` in your b
 cd my-react-app
 npm run dev
 ```
+
+Set `VITE_USE_MOCKS=true` in the `.env` file if you want to work without the
+backend API and use the local mocked data instead.
 
 ## Available scripts
 

--- a/my-react-app/src/services/mockData.js
+++ b/my-react-app/src/services/mockData.js
@@ -1,0 +1,263 @@
+const USER_MAIN_DATA = [
+    {
+        id: 12,
+        userInfos: {
+            firstName: 'Karl',
+            lastName: 'Dovineau',
+            age: 31,
+        },
+        todayScore: 0.12,
+        keyData: {
+            calorieCount: 1930,
+            proteinCount: 155,
+            carbohydrateCount: 290,
+            lipidCount: 50
+        }
+    },
+    {
+        id: 18,
+        userInfos: {
+            firstName: 'Cecilia',
+            lastName: 'Ratorez',
+            age: 34,
+        },
+        score: 0.3,
+        keyData: {
+            calorieCount: 2500,
+            proteinCount: 90,
+            carbohydrateCount: 150,
+            lipidCount: 120
+        }
+    }
+]
+
+const USER_ACTIVITY = [
+    {
+        userId: 12,
+        sessions: [
+            {
+                day: '2020-07-01',
+                kilogram: 80,
+                calories: 240
+            },
+            {
+                day: '2020-07-02',
+                kilogram: 80,
+                calories: 220
+            },
+            {
+                day: '2020-07-03',
+                kilogram: 81,
+                calories: 280
+            },
+            {
+                day: '2020-07-04',
+                kilogram: 81,
+                calories: 290
+            },
+            {
+                day: '2020-07-05',
+                kilogram: 80,
+                calories: 160
+            },
+            {
+                day: '2020-07-06',
+                kilogram: 78,
+                calories: 162
+            },
+            {
+                day: '2020-07-07',
+                kilogram: 76,
+                calories: 390
+            }
+        ]
+    },
+    {
+        userId: 18,
+        sessions: [
+            {
+                day: '2020-07-01',
+                kilogram: 70,
+                calories: 240
+            },
+            {
+                day: '2020-07-02',
+                kilogram: 69,
+                calories: 220
+            },
+            {
+                day: '2020-07-03',
+                kilogram: 70,
+                calories: 280
+            },
+            {
+                day: '2020-07-04',
+                kilogram: 70,
+                calories: 500
+            },
+            {
+                day: '2020-07-05',
+                kilogram: 69,
+                calories: 160
+            },
+            {
+                day: '2020-07-06',
+                kilogram: 69,
+                calories: 162
+            },
+            {
+                day: '2020-07-07',
+                kilogram: 69,
+                calories: 390
+            }
+        ]
+    }
+]
+
+const USER_AVERAGE_SESSIONS = [
+    {
+        userId: 12,
+        sessions: [
+            {
+                day: 1,
+                sessionLength: 30
+            },
+            {
+                day: 2,
+                sessionLength: 23
+            },
+            {
+                day: 3,
+                sessionLength: 45
+            },
+            {
+                day: 4,
+                sessionLength: 50
+            },
+            {
+                day: 5,
+                sessionLength: 0
+            },
+            {
+                day: 6,
+                sessionLength: 0
+            },
+            {
+                day: 7,
+                sessionLength: 60
+            }
+        ]
+    },
+    {
+        userId: 18,
+        sessions: [
+            {
+                day: 1,
+                sessionLength: 30
+            },
+            {
+                day: 2,
+                sessionLength: 40
+            },
+            {
+                day: 3,
+                sessionLength: 50
+            },
+            {
+                day: 4,
+                sessionLength: 30
+            },
+            {
+                day: 5,
+                sessionLength: 30
+            },
+            {
+                day: 6,
+                sessionLength: 50
+            },
+            {
+                day: 7,
+                sessionLength: 50
+            }
+        ]
+    }
+]
+
+const USER_PERFORMANCE = [
+    {
+        userId: 12,
+        kind: {
+            1: 'cardio',
+            2: 'energy',
+            3: 'endurance',
+            4: 'strength',
+            5: 'speed',
+            6: 'intensity'
+        },
+        data: [
+            {
+                value: 80,
+                kind: 1
+            },
+            {
+                value: 120,
+                kind: 2
+            },
+            {
+                value: 140,
+                kind: 3
+            },
+            {
+                value: 50,
+                kind: 4
+            },
+            {
+                value: 200,
+                kind: 5
+            },
+            {
+                value: 90,
+                kind: 6
+            }
+        ]
+    },
+    {
+        userId: 18,
+        kind: {
+            1: 'cardio',
+            2: 'energy',
+            3: 'endurance',
+            4: 'strength',
+            5: 'speed',
+            6: 'intensity'
+        },
+        data: [
+            {
+                value: 200,
+                kind: 1
+            },
+            {
+                value: 240,
+                kind: 2
+            },
+            {
+                value: 80,
+                kind: 3
+            },
+            {
+                value: 80,
+                kind: 4
+            },
+            {
+                value: 220,
+                kind: 5
+            },
+            {
+                value: 110,
+                kind: 6
+            }
+        ]
+    }
+]
+
+export { USER_MAIN_DATA, USER_ACTIVITY, USER_AVERAGE_SESSIONS, USER_PERFORMANCE };

--- a/my-react-app/src/services/userService.js
+++ b/my-react-app/src/services/userService.js
@@ -1,5 +1,8 @@
 // Base URL for API requests comes from the Vite environment variable
 const API_URL = import.meta.env.VITE_API_URL;
+// When this flag is set to "true" in the environment, mocked data will be used
+// instead of performing network requests
+const USE_MOCKS = import.meta.env.VITE_USE_MOCKS === 'true';
 
 import {
   UserMainData,
@@ -7,6 +10,12 @@ import {
   UserAverageSessions,
   UserPerformance,
 } from '../models/userModels.js';
+import {
+  USER_MAIN_DATA,
+  USER_ACTIVITY,
+  USER_AVERAGE_SESSIONS,
+  USER_PERFORMANCE,
+} from './mockData.js';
 
 async function request(endpoint, defaultMessage) {
   try {
@@ -26,6 +35,13 @@ async function request(endpoint, defaultMessage) {
 }
 
 export async function getUserMainData(id) {
+  if (USE_MOCKS) {
+    const raw = USER_MAIN_DATA.find((u) => u.id === Number(id));
+    if (!raw) {
+      throw new Error('Utilisateur inconnu');
+    }
+    return new UserMainData(raw);
+  }
   const data = await request(
     `${API_URL}/${id}`,
     'Impossible de récupérer les données utilisateur'
@@ -34,6 +50,13 @@ export async function getUserMainData(id) {
 }
 
 export async function getUserActivity(id) {
+  if (USE_MOCKS) {
+    const raw = USER_ACTIVITY.find((a) => a.userId === Number(id));
+    if (!raw) {
+      throw new Error('Activité indisponible');
+    }
+    return new UserActivity(raw);
+  }
   const data = await request(
     `${API_URL}/${id}/activity`,
     "Impossible de récupérer l'activité utilisateur"
@@ -42,6 +65,13 @@ export async function getUserActivity(id) {
 }
 
 export async function getUserAverageSessions(id) {
+  if (USE_MOCKS) {
+    const raw = USER_AVERAGE_SESSIONS.find((s) => s.userId === Number(id));
+    if (!raw) {
+      throw new Error('Sessions moyennes indisponibles');
+    }
+    return new UserAverageSessions(raw);
+  }
   const data = await request(
     `${API_URL}/${id}/average-sessions`,
     'Impossible de récupérer les sessions moyennes'
@@ -50,6 +80,13 @@ export async function getUserAverageSessions(id) {
 }
 
 export async function getUserPerformance(id) {
+  if (USE_MOCKS) {
+    const raw = USER_PERFORMANCE.find((p) => p.userId === Number(id));
+    if (!raw) {
+      throw new Error('Performance indisponible');
+    }
+    return new UserPerformance(raw);
+  }
   const data = await request(
     `${API_URL}/${id}/performance`,
     'Impossible de récupérer la performance'


### PR DESCRIPTION
## Summary
- add local mock data to use without the API
- allow switching between API requests and mocked data via `VITE_USE_MOCKS`
- document new environment variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687b5d544b0c8331ba86c05843f0f6e3